### PR TITLE
feat: add homepage components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "next": "15.4.6",
         "papaparse": "^5.5.3",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "lucide-react": "^0.414.0",
+        "recharts": "^2.10.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "next": "15.4.6",
     "papaparse": "^5.5.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "lucide-react": "^0.414.0",
+    "recharts": "^2.10.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,17 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+@layer utilities {
+  .gradient-blue-teal {
+    @apply bg-gradient-to-br from-[#0AAE8A] via-[#0e3c70] to-[#0b2766];
+  }
+  .gradient-yellow-orange {
+    @apply bg-gradient-to-r from-yellow-400 to-orange-500;
+  }
+  .text-teal-bright {
+    @apply text-teal-300;
+  }
+  .data-card {
+    @apply bg-white/10 backdrop-blur-md rounded-3xl shadow-xl;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,446 +1,253 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import Papa from 'papaparse';
+import { useState } from "react";
+import { Header } from "../components/Header";
+import { SearchResults } from "../components/SearchResults";
+import { CommuneProfile } from "../components/CommuneProfile";
+import { CommuneData, searchCommunes, getAllCommunes } from "../services/communeData";
+import { Card } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { ImageWithFallback } from "../components/figma/ImageWithFallback";
+import { Search, BarChart3, Building2, Plus, CheckCircle } from "lucide-react";
 
-/* ---------- Types ---------- */
-type Row = {
-  CODGEO: string;
-  name?: string;
-  P22_POP: number;
-  SUPERF: number;
-  NAIS23: number;
-  DECES23: number;
-  P22_LOG: number;
-  P22_LOGVAC: number;
-  MED21: number;
-  P22_CHOM1564: number;
-  P22_ACT1564: number;
-  P22_POPH: number;
-  P22_POPF: number;
-  C22_POP15P_STAT_GSEC32: number;
-};
+const franceMapImage = "/globe.svg";
 
-const QUICK_CITIES = [
-  { code: '44109', name: 'Nantes' },
-  { code: '69385', name: 'Lyon' },
-  { code: '33063', name: 'Bordeaux' },
-];
-
-/* ========================================================== */
-/*                          PAGE                              */
-/* ========================================================== */
 export default function Home() {
-  const router = useRouter();
-  const [data, setData] = useState<Row[]>([]);
-  const [q, setQ] = useState('');   // recherche principale (CODGEO)
-  const [c1, setC1] = useState(''); // comparer commune 1
-  const [c2, setC2] = useState(''); // comparer commune 2
-  const [focusBox, setFocusBox] = useState<'search' | 'c1' | 'c2' | null>(null);
+  const [appState, setAppState] = useState<"search" | "profile">("search");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<CommuneData[]>([]);
+  const [selectedCommune, setSelectedCommune] = useState<CommuneData | null>(null);
+  const [compareCommune1, setCompareCommune1] = useState("");
+  const [compareCommune2, setCompareCommune2] = useState("");
 
-  useEffect(() => {
-    Papa.parse('/fusion.csv', {
-      download: true,
-      header: true,
-      dynamicTyping: true,
-      skipEmptyLines: true,
-      complete: (res) => {
-        const rows: Row[] = (res.data as any[]).map((r) => ({
-          CODGEO: String(r.CODGEO ?? '').trim(),
-          P22_POP: toNum(r.P22_POP),
-          SUPERF: toNum(r.SUPERF),
-          NAIS23: toNum(r.NAIS23),
-          DECES23: toNum(r.DECES23),
-          P22_LOG: toNum(r.P22_LOG),
-          P22_LOGVAC: toNum(r.P22_LOGVAC),
-          MED21: toNum(r.MED21),
-          P22_CHOM1564: toNum(r.P22_CHOM1564),
-          P22_ACT1564: toNum(r.P22_ACT1564),
-          P22_POPH: toNum(r.P22_POPH),
-          P22_POPF: toNum(r.P22_POPF),
-          C22_POP15P_STAT_GSEC32: toNum(r.C22_POP15P_STAT_GSEC32),
-        }));
-        fetch('https://geo.api.gouv.fr/communes?fields=nom,code&format=json')
-          .then((r) => r.json())
-          .then((list: any[]) => {
-            const map = new Map(list.map((c) => [c.code, c.nom]));
-            setData(rows.map((r) => ({ ...r, name: map.get(r.CODGEO) })));
-          })
-          .catch(() => setData(rows));
-      },
-    });
-  }, []);
+  const handleSearch = (query: string) => {
+    const results = searchCommunes(query);
+    setSearchResults(results);
+  };
 
-  const suggestions = useMemo(() => {
-    const term =
-      (focusBox === 'search' ? q : focusBox === 'c1' ? c1 : focusBox === 'c2' ? c2 : '')
-        .toLowerCase();
-    if (!term) return [];
-    return data
-      .filter(
-        (r) =>
-          r.CODGEO.toLowerCase().includes(term) ||
-          (r.name ?? '').toLowerCase().includes(term)
-      )
-      .slice(0, 8);
-  }, [data, q, c1, c2, focusBox]);
+  const handleSelectCommune = (commune: CommuneData) => {
+    setSelectedCommune(commune);
+    setAppState("profile");
+  };
 
-  const trends = useMemo(() => {
-    // “Top tendances” approximé : (naissances - décès) / population
-    const scored = data
-      .map((r) => ({
-        row: r,
-        score:
-          Number.isFinite(r.P22_POP) && r.P22_POP > 0
-            ? (((r.NAIS23 || 0) - (r.DECES23 || 0)) / r.P22_POP) * 100
-            : -Infinity,
-      }))
-      .filter((x) => Number.isFinite(x.score));
-    scored.sort((a, b) => (b.score as number) - (a.score as number));
-    return scored.slice(0, 6).map((x) => x.row);
-  }, [data]);
+  const handleBack = () => {
+    setAppState("search");
+    setSelectedCommune(null);
+    setSearchResults([]);
+  };
 
-  function goExplore() {
-    const term = q.trim().toLowerCase();
-    const row = data.find(
-      (r) => r.CODGEO.toLowerCase() === term || (r.name ?? '').toLowerCase() === term
-    );
-    if (!row) return;
-    router.push(`/commune/${encodeURIComponent(row.CODGEO)}/v2`);
-  }
-  function goCompare() {
-    const t1 = c1.trim().toLowerCase();
-    const t2 = c2.trim().toLowerCase();
-    const r1 = data.find(
-      (r) => r.CODGEO.toLowerCase() === t1 || (r.name ?? '').toLowerCase() === t1
-    );
-    const r2 = data.find(
-      (r) => r.CODGEO.toLowerCase() === t2 || (r.name ?? '').toLowerCase() === t2
-    );
-    if (!r1 || !r2) return;
-    router.push(
-      `/commune/${encodeURIComponent(r1.CODGEO)}/v2?compare=${encodeURIComponent(r2.CODGEO)}`
+  const handleQuickSearch = (city: string) => {
+    setSearchQuery(city);
+    handleSearch(city);
+  };
+
+  getAllCommunes();
+
+  if (appState === "profile" && selectedCommune) {
+    return (
+      <div className="min-h-screen">
+        <div className="gradient-blue-teal">
+          <Header onSearch={handleSearch} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+        </div>
+        <CommuneProfile commune={selectedCommune} onBack={handleBack} />
+      </div>
     );
   }
 
   return (
-    <main className="min-h-screen text-white bg-gradient-to-br from-[#0AAE8A] via-[#0e3c70] to-[#0b2766]">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-5">
-        {/* NAV */}
-        <nav className="flex items-center justify-between rounded-2xl bg-[#0c2a55]/60 px-4 py-3 ring-1 ring-white/10 backdrop-blur-md">
-          <div className="flex items-center gap-3">
-            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 ring-1 ring-white/15">📍</span>
-            <span className="text-lg font-semibold">CommuneData</span>
-          </div>
-          <div className="flex items-center gap-6 text-sm">
-            <a href="#" className="opacity-90 hover:opacity-100">
-              Données
-            </a>
-            <a href="#" className="opacity-90 hover:opacity-100">
-              Comparer
-            </a>
-            <a href="#" className="opacity-90 hover:opacity-100">
-              À propos
-            </a>
-            <button
-              type="button"
-              aria-label="Ouvrir le menu"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/10"
-            >
-              ☰
-            </button>
-          </div>
-        </nav>
+    <div className="min-h-screen bg-white">
+      <div className="gradient-blue-teal relative overflow-hidden min-h-[70vh]">
+        <div className="absolute right-0 top-0 bottom-0 w-1/2 max-w-lg opacity-30">
+          <img src={franceMapImage} alt="Carte de France" className="h-full w-full object-contain object-center-right france-map" />
+        </div>
 
-        {/* HERO CONTAINER */}
-        <section className="mt-5 grid grid-cols-1 gap-6 lg:grid-cols-[1.25fr,0.75fr]">
-          {/* LEFT: Title + Search + Compare */}
-          <div className="rounded-[28px] bg-gradient-to-br from-[#0b3164] via-[#0b2b56] to-[#0d2550] p-7 ring-1 ring-white/10 shadow-xl backdrop-blur-md">
-            <h1 className="text-[44px] leading-[1.05] font-semibold tracking-tight">
-              Découvrez<br /> votre commune
+        <Header onSearch={handleSearch} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+
+        <div className="relative z-10 max-w-7xl mx-auto px-6 pt-8 pb-16">
+          <div className="max-w-2xl">
+            <h1 className="text-7xl font-bold text-white mb-12 leading-tight">
+              Découvrez<br />
+              votre commune
             </h1>
 
-            {/* Search bar */}
-            <div className="mt-6 flex items-stretch gap-2">
-              <div className="relative flex-1">
-                <input
-                  value={q}
-                  onChange={(e) => setQ(e.target.value)}
-                  onFocus={() => setFocusBox('search')}
-                  onBlur={() => setTimeout(() => setFocusBox(null), 150)}
-                  placeholder="Rechercher une commune"
-                  className="w-full rounded-2xl bg-white/10 px-4 py-3 pr-3 text-white placeholder-white/60 outline-none ring-1 ring-white/10 focus:ring-2 focus:ring-[#6D5EF3]"
-                />
-                {focusBox === 'search' && suggestions.length > 0 && (
-                  <ul className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl bg-[#0e2a51] ring-1 ring-white/10">
-                    {suggestions.map((s) => (
-                      <li
-                        key={s.CODGEO}
-                        className="cursor-pointer px-4 py-2 hover:bg-white/5"
-                        onMouseDown={() => setQ(s.name || s.CODGEO)}
-                      >
-                        {(s.name || s.CODGEO)} <span className="opacity-60">• {fmtPop(s.P22_POP)} hab.</span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-              <button
-                onClick={goExplore}
-                className="rounded-2xl bg-gradient-to-r from-[#6D5EF3] to-[#F59E0B] px-5 py-3 font-medium text-white shadow-lg hover:brightness-110"
-              >
-                Explorer
-              </button>
-            </div>
-
-            {/* city chips */}
-            <div className="mt-3 flex flex-wrap gap-2">
-              {QUICK_CITIES.map((c) => (
-                <button
-                  key={c.code}
-                  onClick={() => setQ(c.name)}
-                  className="rounded-full bg-white/10 px-3 py-1 text-sm ring-1 ring-white/10 hover:bg-white/15"
+            <div className="mb-8">
+              <form onSubmit={(e) => { e.preventDefault(); handleSearch(searchQuery); }} className="flex space-x-4">
+                <div className="flex-1 relative">
+                  <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+                  <Input
+                    type="text"
+                    placeholder="Rechercher une commune"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-14 h-16 text-lg bg-white border-0 rounded-2xl shadow-xl font-medium text-gray-900 placeholder:text-gray-500"
+                  />
+                </div>
+                <Button
+                  type="submit"
+                  className="h-16 px-10 bg-orange-500 hover:bg-orange-600 text-white rounded-2xl shadow-xl font-bold text-lg"
                 >
-                  {c.name}
-                </button>
-              ))}
+                  Explorer
+                </Button>
+              </form>
             </div>
 
-            {/* Compare panel */}
-            <div className="mt-6 grid grid-cols-1 gap-4 rounded-2xl bg-white/10 p-4 ring-1 ring-white/10 md:grid-cols-[1fr,1fr,auto]">
-              <InputSuggest
-                value={c1}
-                setValue={setC1}
-                label="Commune 1"
-                data={data}
-                onFocus={() => setFocusBox('c1')}
-                onBlur={() => setTimeout(() => setFocusBox(null), 150)}
-                open={focusBox === 'c1'}
-              />
-              <InputSuggest
-                value={c2}
-                setValue={setC2}
-                label="Commune 2"
-                data={data}
-                onFocus={() => setFocusBox('c2')}
-                onBlur={() => setTimeout(() => setFocusBox(null), 150)}
-                open={focusBox === 'c2'}
-              />
-              <button
-                onClick={goCompare}
-                disabled={!c1 || !c2}
-                className="h-12 rounded-xl bg-[#5B8F64] px-5 font-medium text-white shadow disabled:opacity-50"
-              >
-                Comparer
-              </button>
+            <div className="flex space-x-8">
+              <button onClick={() => handleQuickSearch('Nantes')} className="text-white/90 hover:text-white underline font-medium text-lg">Nantes</button>
+              <button onClick={() => handleQuickSearch('Lyon')} className="text-white/90 hover:text-white underline font-medium text-lg">Lyon</button>
+              <button onClick={() => handleQuickSearch('Bordeaux')} className="text-white/90 hover:text-white underline font-medium text-lg">Bordeaux</button>
             </div>
           </div>
+        </div>
 
-          {/* RIGHT: Map */}
-          <div className="rounded-[28px] bg-gradient-to-br from-[#0b3164] via-[#0b2b56] to-[#0d2550] p-7 ring-1 ring-white/10 shadow-xl backdrop-blur-md">
-            <FranceMapLarge />
+        {searchResults.length > 0 && (
+          <div className="relative z-10 bg-white/95 backdrop-blur-sm rounded-t-3xl">
+            <SearchResults communes={searchResults} onSelectCommune={handleSelectCommune} />
           </div>
-        </section>
-
-        {/* TOP TRENDS */}
-        <section className="mt-8">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-2xl font-semibold">Top tendances</h2>
-            <span className="text-sm opacity-80">Annonce</span>
-          </div>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {trends.map((r) => (
-              <TrendCard key={r.CODGEO} row={r} />
-            ))}
-          </div>
-        </section>
-
-        {/* SOURCES */}
-        <section className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <SourceCard icon="📈" label="INSEE" />
-          <SourceCard icon="🛂" label="Ministère de l’intérieur" />
-          <SourceCard icon="🏥" label="Santé" />
-        </section>
-
-        {/* TRUST + METRICS */}
-        <section className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-          <div className="rounded-2xl bg-[#F3C76A] p-6 text-[#1f2937] shadow">
-            <h3 className="text-2xl font-semibold">Pourquoi nous faire confiance</h3>
-            <ul className="mt-3 list-disc pl-6 space-y-1">
-              <li>Données issues de fichiers publics (CSV local).</li>
-              <li>Mise en forme claire : cartes, tendances, comparaison.</li>
-              <li>Respect de la vie privée : aucun envoi serveur des saisies.</li>
-            </ul>
-          </div>
-          <div className="rounded-2xl bg-white/5 p-6 ring-1 ring-white/10 backdrop-blur">
-            <div className="text-sm opacity-80">Disponibilité</div>
-            <Progress value={92} />
-            <div className="mt-4 text-sm opacity-80">Couverture des indicateurs</div>
-            <Progress value={78} accent="#52E3E1" />
-          </div>
-        </section>
-
-        {/* FOOTER */}
-        <footer className="mt-10 flex items-center justify-between opacity-80 text-sm">
-          <div>© CommuneData</div>
-          <a className="underline" href="/fusion.csv" download>Télécharger CSV</a>
-        </footer>
+        )}
       </div>
-    </main>
-  );
-}
 
-/* ================= Components ================= */
+      {searchResults.length === 0 && (
+        <div className="bg-white">
+          <div className="max-w-7xl mx-auto px-6 py-16">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-20">
+              <div>
+                <h2 className="text-3xl font-bold text-gray-900 mb-10">Comparer une commune</h2>
+                <div className="space-y-5">
+                  <Input
+                    placeholder="Commune 1"
+                    value={compareCommune1}
+                    onChange={(e) => setCompareCommune1(e.target.value)}
+                    className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
+                  />
+                  <Input
+                    placeholder="Commune 2"
+                    value={compareCommune2}
+                    onChange={(e) => setCompareCommune2(e.target.value)}
+                    className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
+                  />
+                  <Button className="w-full h-16 bg-teal-600 hover:bg-teal-700 text-white rounded-2xl font-bold text-lg">
+                    Comparer
+                  </Button>
+                </div>
+              </div>
 
-function InputSuggest({
-  value,
-  setValue,
-  label,
-  data,
-  onFocus,
-  onBlur,
-  open,
-}: {
-  value: string;
-  setValue: (s: string) => void;
-  label: string;
-  data: Row[];
-  onFocus: () => void;
-  onBlur: () => void;
-  open: boolean;
-  }) {
-    const list = useMemo(() => {
-      const term = value.toLowerCase();
-      if (!term) return [];
-      return data
-        .filter(
-          (r) =>
-            r.CODGEO.toLowerCase().includes(term) ||
-            (r.name ?? '').toLowerCase().includes(term)
-        )
-        .slice(0, 6);
-    }, [data, value]);
+              <div>
+                <div className="flex items-center justify-end mb-8">
+                  <span className="text-sm text-gray-500 font-medium">Annonce</span>
+                </div>
+                <div className="grid grid-cols-3 gap-6">
+                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Châtenay-Malabry')}>
+                    <div className="relative">
+                      <ImageWithFallback
+                        src="https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=300&h=160&fit=crop"
+                        alt="Châtenay-Malabry"
+                        className="w-full h-32 object-cover"
+                      />
+                      <div className="absolute top-3 right-3">
+                        <span className="bg-yellow-400 text-black text-xs px-3 py-1.5 rounded-lg font-bold">
+                          Annoncé
+                        </span>
+                      </div>
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-bold text-base mb-3 text-gray-900">Chatenay-Malabry</h3>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
+                        <span className="text-base font-semibold text-gray-700">2.8%</span>
+                      </div>
+                    </div>
+                  </Card>
 
-  return (
-    <div className="relative">
-      <input
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        placeholder={label}
-        className="h-12 w-full rounded-xl bg-white/10 px-4 text-white placeholder-white/70 outline-none ring-1 ring-white/10 focus:ring-2 focus:ring-[#5EEAD4]"
-      />
-      {open && list.length > 0 && (
-        <ul className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl bg-[#0e2a51] ring-1 ring-white/10">
-            {list.map((s) => (
-              <li
-                key={s.CODGEO}
-                className="cursor-pointer px-4 py-2 hover:bg-white/5"
-                onMouseDown={() => setValue(s.name || s.CODGEO)}
-              >
-                {(s.name || s.CODGEO)} <span className="opacity-60">• {fmtPop(s.P22_POP)} hab.</span>
-              </li>
-            ))}
-        </ul>
+                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Dardilly')}>
+                    <div className="relative">
+                      <ImageWithFallback
+                        src="https://images.unsplash.com/photo-1449824913935-59a10b8d2000?w=300&h=160&fit=crop"
+                        alt="Dardilly"
+                        className="w-full h-32 object-cover"
+                      />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-bold text-base mb-3 text-gray-900">Dardilly</h3>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
+                        <span className="text-base font-semibold text-gray-700">13%</span>
+                      </div>
+                    </div>
+                  </Card>
+
+                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Perpignan')}>
+                    <div className="relative">
+                      <ImageWithFallback
+                        src="https://images.unsplash.com/photo-1467269204594-9661b134dd2b?w=300&h=160&fit=crop"
+                        alt="Perpignan"
+                        className="w-full h-32 object-cover"
+                      />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-bold text-base mb-3 text-gray-900">Perpignan</h3>
+                      <div className="flex items-center space-x-2">
+                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
+                        <span className="text-base font-semibold text-gray-700">0.47%</span>
+                      </div>
+                    </div>
+                  </Card>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-24">
+              <div className="flex items-center justify-between mb-12">
+                <h2 className="text-3xl font-bold text-gray-900">Top tendances</h2>
+                <span className="text-sm text-gray-500 font-medium">Annonce</span>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-16">
+                <div className="flex items-center space-x-6">
+                  <div className="w-20 h-20 bg-yellow-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+                    <BarChart3 className="h-10 w-10 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-xl text-gray-900">INSEE</h3>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-6">
+                  <div className="w-20 h-20 bg-blue-600 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+                    <Building2 className="h-10 w-10 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-xl text-gray-900">Ministère de l'intérieur</h3>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-6">
+                  <div className="w-20 h-20 bg-red-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+                    <Plus className="h-10 w-10 text-white" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-xl text-gray-900">Santé</h3>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-24">
+              <div className="gradient-yellow-orange rounded-3xl p-12 shadow-xl">
+                <h2 className="text-3xl font-bold text-gray-900 mb-8">Pourquoi nous faire confiance</h2>
+                <div className="space-y-6">
+                  <div className="flex items-center space-x-4">
+                    <CheckCircle className="h-6 w-6 text-gray-900" />
+                    <span className="text-gray-900 font-semibold text-lg">Faits marquant</span>
+                  </div>
+                  <div className="flex items-center space-x-4">
+                    <CheckCircle className="h-6 w-6 text-gray-900" />
+                    <span className="text-gray-900 font-semibold text-lg">Évaluation par Ministre de la Santé</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );
 }
 
-function TrendCard({ row }: { row: Row }) {
-  const growth =
-    Number.isFinite(row.P22_POP) && row.P22_POP > 0
-      ? (((row.NAIS23 || 0) - (row.DECES23 || 0)) / row.P22_POP) * 100
-      : 0;
-  return (
-    <div className="rounded-2xl bg-white/5 p-4 ring-1 ring-white/10 backdrop-blur shadow-lg">
-      <div className="relative mb-3 h-28 w-full overflow-hidden rounded-xl">
-        <div className="absolute inset-0 bg-gradient-to-br from-[#2dd4bf] to-[#3b82f6]" />
-        <span className="absolute left-2 top-2 rounded-md bg-black/30 px-2 py-1 text-xs">Annonce</span>
-      </div>
-      <div className="text-lg font-semibold">{row.name || row.CODGEO}</div>
-      <div className={`mt-1 text-sm ${growth >= 0 ? 'text-teal-300' : 'text-orange-300'}`}>
-        {growth >= 0 ? '▲' : '▼'} {fmtNumber(Math.abs(growth))} %
-      </div>
-      <div className="mt-2 text-xs opacity-80">
-        Pop : {fmtPop(row.P22_POP)} • Surf : {fmtArea(row.SUPERF)}
-      </div>
-    </div>
-  );
-}
-
-function SourceCard({ icon, label }: { icon: string; label: string }) {
-  return (
-    <div className="rounded-2xl bg-white/5 p-5 ring-1 ring-white/10 backdrop-blur">
-      <div className="flex items-center gap-3">
-        <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-xl">{icon}</span>
-        <span className="text-lg font-medium">{label}</span>
-      </div>
-    </div>
-  );
-}
-
-function FranceMapLarge() {
-  return (
-    <svg
-      viewBox="0 0 100 100"
-      className="h-72 w-full"
-      role="img"
-      aria-label="Carte de la France"
-    >
-      <defs>
-        <linearGradient id="mapg" x1="0" x2="1" y1="0" y2="1">
-          <stop offset="0%" stopColor="#52E3E1" />
-          <stop offset="100%" stopColor="#22c55e" />
-        </linearGradient>
-      </defs>
-      <path
-        d="M62 9l5 6 7-1 5 6-5 7 4 5-2 7 3 6-4 6-1 6-6 4-1 6-8 2-5 6-9-1-8-6-9 1-6-6-7-1-1-7 4-6-2-6 6-5-1-8 6-3 6-5 8 2 7-4 7 2z"
-        fill="url(#mapg)"
-        opacity={0.9}
-      />
-      {/* Corse */}
-      <circle cx="86" cy="88" r="4" fill="url(#mapg)" opacity={0.9} />
-    </svg>
-  );
-}
-
-function Progress({ value, accent = '#3B82F6' }: { value: number; accent?: string }) {
-  return (
-    <div className="mt-1 h-3 w-full overflow-hidden rounded-full bg-white/10 ring-1 ring-white/15">
-      <div
-        className="h-full rounded-full"
-        style={{
-          width: `${Math.max(0, Math.min(100, value))}%`,
-          background: `linear-gradient(90deg, ${accent}, rgba(59,130,246,0.2))`,
-        }}
-      />
-    </div>
-  );
-}
-
-/* ================= Utils ================= */
-
-function toNum(v: any): number {
-  if (v == null || v === '') return NaN as unknown as number;
-  if (typeof v === 'number') return v;
-  const s = String(v).replace(/\s/g, '').replace(',', '.');
-  const n = Number(s);
-  return isNaN(n) ? (NaN as unknown as number) : n;
-}
-function fmtNumber(n?: number) {
-  return Number.isFinite(n) ? Number(n!).toLocaleString('fr-FR', { maximumFractionDigits: 3 }) : '—';
-}
-function fmtPop(n: number) {
-  if (!Number.isFinite(n)) return '—';
-  if (n >= 1_000_000) return `${(n / 1_000_000).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} M`;
-  if (n >= 1_000) return `${(n / 1_000).toLocaleString('fr-FR', { maximumFractionDigits: 0 })} k`;
-  return n.toLocaleString('fr-FR');
-}
-  function fmtArea(n: number) {
-    if (!Number.isFinite(n)) return '—';
-    const rounded = Math.round(n);
-    return `${rounded.toLocaleString('fr-FR')} km²`;
-  }

--- a/src/components/CommuneProfile.tsx
+++ b/src/components/CommuneProfile.tsx
@@ -1,0 +1,264 @@
+import { CommuneData } from "../services/communeData";
+import { Card } from "./ui/card";
+import { Button } from "./ui/button";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  Tooltip,
+} from "recharts";
+import { ArrowLeft, TrendingUp } from "lucide-react";
+import franceMapImage from "/globe.svg";
+
+interface CommuneProfileProps {
+  commune: CommuneData;
+  onBack: () => void;
+}
+
+export function CommuneProfile({ commune, onBack }: CommuneProfileProps) {
+  const healthData = [
+    { name: "Couvert", value: 53, color: "#14b8a6" },
+    { name: "Non couvert", value: 47, color: "#0891b2" },
+  ];
+
+  const crimeBarData = [
+    { name: "Vols", value: 25 },
+    { name: "Violences", value: 15 },
+  ];
+
+  const evolutionData = [
+    { year: "2020", value: 85 },
+    { year: "2021", value: 90 },
+    { year: "2022", value: 88 },
+    { year: "2023", value: 95 },
+    { year: "2024", value: 92 },
+  ];
+
+  const districts = [
+    { name: "1er", population: "27 630", trend: "up" },
+    { name: "2e", population: "27 630", trend: "up" },
+    { name: "3re", population: "22 520", trend: "down" },
+    { name: "4re", population: "22 520", trend: "down" },
+  ];
+
+  return (
+    <div className="min-h-screen">
+      <div className="gradient-blue-teal relative overflow-hidden min-h-screen">
+        <div className="absolute right-0 top-0 bottom-0 w-1/2 max-w-lg opacity-30">
+          <img
+            src={franceMapImage}
+            alt="Carte de France"
+            className="h-full w-full object-contain object-center-right france-map"
+          />
+        </div>
+
+        <div className="relative z-10">
+          <div className="max-w-7xl mx-auto px-6 pt-8">
+            <Button
+              variant="ghost"
+              onClick={onBack}
+              className="text-white hover:bg-white/10 mb-8"
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
+          </div>
+
+          <div className="max-w-7xl mx-auto px-6 mb-12">
+            <div className="max-w-2xl">
+              <h1 className="text-6xl font-bold text-white mb-6">
+                {commune.name} ({commune.postalCode.substring(0, 2)})
+              </h1>
+              <div className="flex space-x-8 text-white/90 text-lg">
+                <span>{(commune.population / 1000000).toFixed(2)} M hab.</span>
+                <span>105 km²</span>
+                <span>Dernière mise à jour : 4 juin 2025</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="max-w-7xl mx-auto px-6 pb-12">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+              <Card className="data-card p-6 text-white">
+                <h3 className="text-xl font-semibold mb-2">Revenu médian</h3>
+                <div className="text-4xl font-bold text-teal-bright mb-4">
+                  {commune.income.medianIncome.toLocaleString()} €
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center text-sm">
+                    <TrendingUp className="h-4 w-4 mr-2 text-green-400" />
+                    <span>+1.5% vs dép.</span>
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <TrendingUp className="h-4 w-4 mr-2 text-green-400" />
+                    <span>+0.3% vs fr.</span>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="data-card p-6 text-white">
+                <h3 className="text-xl font-semibold mb-4">Prix immobilier</h3>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="text-sm text-white/70">Vols</p>
+                    <div className="h-16 bg-teal-bright rounded"></div>
+                  </div>
+                  <div>
+                    <p className="text-sm text-white/70">Violences</p>
+                    <div className="h-10 bg-blue-400 rounded"></div>
+                  </div>
+                </div>
+                <p className="text-sm text-white/70">vs département ↗</p>
+              </Card>
+
+              <Card className="data-card p-6 text-white">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-xl font-semibold">Santé</h3>
+                  <span className="text-sm text-teal-bright">vs Pontarlier</span>
+                </div>
+                <div className="mb-4">
+                  <div className="text-2xl font-bold text-teal-bright mb-1">12</div>
+                  <p className="text-sm text-white/70">médecins /10k hab.</p>
+                </div>
+                <div className="mb-4">
+                  <div className="text-2xl font-bold text-white mb-1">7</div>
+                  <p className="text-sm text-white/70">cabinets médicaux</p>
+                </div>
+                <div className="relative w-20 h-20 mx-auto">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={healthData}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={25}
+                        outerRadius={40}
+                        dataKey="value"
+                        startAngle={90}
+                        endAngle={450}
+                      >
+                        {healthData.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={entry.color} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="text-center">
+                      <div className="text-xs font-bold text-white">53%</div>
+                      <div className="text-xs font-bold text-white">47%</div>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="data-card p-6 text-white">
+                <h3 className="text-xl font-semibold mb-2">Délinquance</h3>
+                <p className="text-sm text-white/70 mb-4">/1000 hab.</p>
+                <div className="h-32">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={crimeBarData}>
+                      <Bar dataKey="value" fill="#14b8a6" radius={[4, 4, 0, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+
+              <Card className="data-card p-6 text-white">
+                <h3 className="text-xl font-semibold mb-2">Santé</h3>
+                <div className="text-2xl font-bold text-teal-bright mb-1">12</div>
+                <p className="text-sm text-white/70 mb-4">médecins /10k hab.</p>
+                <div className="h-16">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={evolutionData.slice(0, 3)}>
+                      <Line type="monotone" dataKey="value" stroke="#14b8a6" strokeWidth={2} dot={false} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+
+              <Card className="gradient-yellow-orange p-6">
+                <div className="text-center">
+                  <p className="text-teal-bright font-semibold mb-2">Annonce</p>
+                  <div className="h-24 bg-white/20 rounded-lg flex items-center justify-center">
+                    <span className="text-gray-800 font-bold">Annonce</span>
+                  </div>
+                </div>
+              </Card>
+            </div>
+
+            <div className="mb-8">
+              <Button className="w-full max-w-md bg-teal-600 hover:bg-teal-700 text-white h-14 rounded-xl font-bold text-lg">
+                Comparer cette commune
+              </Button>
+            </div>
+
+            <Card className="data-card p-6 text-white mb-8">
+              <h3 className="text-2xl font-semibold mb-6">Évolution 5 ans</h3>
+              <div className="h-40">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={evolutionData}>
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke="#14b8a6"
+                      strokeWidth={3}
+                      dot={{ fill: "#14b8a6", strokeWidth: 2, r: 4 }}
+                    />
+                    <XAxis dataKey="year" axisLine={false} tickLine={false} tick={{ fill: 'white', fontSize: 12 }} />
+                    <YAxis hide />
+                    <Tooltip contentStyle={{ backgroundColor: 'rgba(255,255,255,0.1)', border: 'none', borderRadius: '8px', color: 'white' }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+              <Card className="data-card p-6 text-white">
+                <div className="flex items-center justify-between mb-6">
+                  <h3 className="text-2xl font-semibold">Quartiers (arrondissements)</h3>
+                  <span className="text-sm text-teal-bright">Voir la fiche</span>
+                </div>
+                <div className="space-y-4">
+                  {districts.map((district, index) => (
+                    <div key={index} className="flex items-center justify-between">
+                      <div className="flex items-center space-x-4">
+                        <span className="text-lg font-semibold">{district.name}</span>
+                        <span className="text-sm text-white/70">Population</span>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <span className="font-semibold">{district.population}</span>
+                        <span className="text-sm text-teal-bright">Voir la fiche</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+
+              <Card className="gradient-yellow-orange p-8">
+                <div className="text-center mb-4">
+                  <p className="text-teal-bright font-semibold mb-4">Annonce</p>
+                </div>
+                <div className="bg-orange-400 rounded-2xl p-8 text-center">
+                  <p className="text-gray-800 font-bold text-xl mb-2">Annonce</p>
+                  <p className="text-gray-800 text-lg">300 x 600</p>
+                </div>
+                <div className="mt-4 text-center">
+                  <p className="text-teal-bright font-semibold">Annonce</p>
+                </div>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,45 @@
+import { Menu } from "lucide-react";
+import { Button } from "./ui/button";
+
+interface HeaderProps {
+  onSearch: (query: string) => void;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+}
+
+export function Header({ onSearch, searchQuery, setSearchQuery }: HeaderProps) {
+  return (
+    <header className="relative z-50">
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <div className="flex items-center justify-between">
+          {/* Logo - Plus espacé */}
+          <div className="flex items-center space-x-4">
+            <div className="w-10 h-10 bg-white/20 rounded-full flex items-center justify-center backdrop-blur-sm">
+              <span className="text-white font-bold text-lg">C</span>
+            </div>
+            <span className="text-white font-bold text-xl">CommuneData</span>
+          </div>
+          
+          {/* Navigation Desktop - Meilleur espacement */}
+          <nav className="hidden md:flex items-center space-x-10">
+            <a href="#" className="text-white/90 hover:text-white transition-colors font-medium text-lg">
+              Données
+            </a>
+            <a href="#" className="text-white/90 hover:text-white transition-colors font-medium text-lg">
+              Comparer
+            </a>
+            <a href="#" className="text-white/90 hover:text-white transition-colors font-medium text-lg">
+              À propos
+            </a>
+          </nav>
+          
+          {/* Menu Hamburger Mobile */}
+          <Button variant="ghost" size="icon" className="md:hidden text-white hover:bg-white/10">
+            <Menu className="h-6 w-6" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}
+

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,31 @@
+import { CommuneData } from "../services/communeData";
+import { Card } from "./ui/card";
+
+interface SearchResultsProps {
+  communes: CommuneData[];
+  onSelectCommune: (commune: CommuneData) => void;
+}
+
+export function SearchResults({ communes, onSelectCommune }: SearchResultsProps) {
+  if (communes.length === 0) return null;
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-8">
+      <ul className="space-y-4">
+        {communes.map((c) => (
+          <li key={c.id}>
+            <Card
+              className="p-4 cursor-pointer hover:bg-gray-50"
+              onClick={() => onSelectCommune(c)}
+            >
+              <div className="flex justify-between">
+                <span className="font-medium">{c.name}</span>
+                <span className="text-sm text-gray-500">{c.postalCode}</span>
+              </div>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+const ERROR_IMG_SRC =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Rya2Utd2lkdGg9IjMuNyI+PHJlY3QgeD0iMTYiIHk9IjE2IiB3aWR0aD0iNTYiIGhlaWdodD0iNTYiIHJ4PSI2Ii8+PHBhdGggZD0ibTE2IDU4IDE2LTE4IDMyIDMyIi8+PGNpcmNsZSBjeD0iNTMiIGN5PSIzNSIgcj0iNyIvPjwvc3ZnPgoK';
+
+export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const [didError, setDidError] = useState(false);
+
+  const handleError = () => {
+    setDidError(true);
+  };
+
+  const { src, alt, style, className, ...rest } = props;
+
+  return didError ? (
+    <div
+      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ''}`}
+      style={style}
+    >
+      <div className="flex items-center justify-center w-full h-full">
+        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+      </div>
+    </div>
+  ) : (
+    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+  );
+}
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, children, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={`inline-flex items-center justify-center rounded-md ${className ?? ''}`}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+);
+Button.displayName = 'Button';
+

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export function Card(
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement>
+) {
+  return <div className={`rounded-2xl bg-white shadow ${className ?? ''}`} {...props} />;
+}
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} className={`rounded-md ${className ?? ''}`} {...props} />
+  )
+);
+Input.displayName = 'Input';
+

--- a/src/services/communeData.ts
+++ b/src/services/communeData.ts
@@ -1,0 +1,201 @@
+export interface CommuneData {
+  id: string;
+  name: string;
+  postalCode: string;
+  department: string;
+  region: string;
+  population: number;
+  demographics: {
+    malePercentage: number;
+    femalePercentage: number;
+  };
+  realEstate: {
+    medianPricePerM2: number;
+    averagePurchasePrice: number;
+  };
+  medical: {
+    doctorsCount: number;
+    medicalCentersCount: number;
+    pharmaciesCount: number;
+  };
+  crime: {
+    totalCrimesPerThousand: number;
+    crimeBySeverity: {
+      minor: number;
+      moderate: number;
+      severe: number;
+    };
+  };
+  income: {
+    medianIncome: number;
+  };
+  comparisons: {
+    department: {
+      realEstate: number;
+      crime: number;
+      income: number;
+    };
+    national: {
+      realEstate: number;
+      crime: number;
+      income: number;
+    };
+  };
+}
+
+// Mock data for demonstration
+const mockCommunes: CommuneData[] = [
+  {
+    id: "paris-75001",
+    name: "Paris 1er",
+    postalCode: "75001",
+    department: "Paris",
+    region: "Île-de-France",
+    population: 16600,
+    demographics: {
+      malePercentage: 46.2,
+      femalePercentage: 53.8,
+    },
+    realEstate: {
+      medianPricePerM2: 15200,
+      averagePurchasePrice: 1520000,
+    },
+    medical: {
+      doctorsCount: 45,
+      medicalCentersCount: 8,
+      pharmaciesCount: 12,
+    },
+    crime: {
+      totalCrimesPerThousand: 89.3,
+      crimeBySeverity: {
+        minor: 65.2,
+        moderate: 18.7,
+        severe: 5.4,
+      },
+    },
+    income: {
+      medianIncome: 54200,
+    },
+    comparisons: {
+      department: {
+        realEstate: 112,
+        crime: 145,
+        income: 138,
+      },
+      national: {
+        realEstate: 185,
+        crime: 178,
+        income: 167,
+      },
+    },
+  },
+  {
+    id: "lyon-69001",
+    name: "Lyon 1er",
+    postalCode: "69001",
+    department: "Rhône",
+    region: "Auvergne-Rhône-Alpes",
+    population: 29800,
+    demographics: {
+      malePercentage: 48.1,
+      femalePercentage: 51.9,
+    },
+    realEstate: {
+      medianPricePerM2: 6850,
+      averagePurchasePrice: 485000,
+    },
+    medical: {
+      doctorsCount: 38,
+      medicalCentersCount: 6,
+      pharmaciesCount: 9,
+    },
+    crime: {
+      totalCrimesPerThousand: 52.7,
+      crimeBySeverity: {
+        minor: 38.4,
+        moderate: 11.2,
+        severe: 3.1,
+      },
+    },
+    income: {
+      medianIncome: 38700,
+    },
+    comparisons: {
+      department: {
+        realEstate: 108,
+        crime: 105,
+        income: 119,
+      },
+      national: {
+        realEstate: 132,
+        crime: 105,
+        income: 119,
+      },
+    },
+  },
+  {
+    id: "marseille-13001",
+    name: "Marseille 1er",
+    postalCode: "13001",
+    department: "Bouches-du-Rhône",
+    region: "Provence-Alpes-Côte d'Azur",
+    population: 38200,
+    demographics: {
+      malePercentage: 49.3,
+      femalePercentage: 50.7,
+    },
+    realEstate: {
+      medianPricePerM2: 4200,
+      averagePurchasePrice: 315000,
+    },
+    medical: {
+      doctorsCount: 28,
+      medicalCentersCount: 4,
+      pharmaciesCount: 7,
+    },
+    crime: {
+      totalCrimesPerThousand: 67.2,
+      crimeBySeverity: {
+        minor: 48.1,
+        moderate: 14.8,
+        severe: 4.3,
+      },
+    },
+    income: {
+      medianIncome: 28900,
+    },
+    comparisons: {
+      department: {
+        realEstate: 95,
+        crime: 118,
+        income: 87,
+      },
+      national: {
+        realEstate: 81,
+        crime: 134,
+        income: 89,
+      },
+    },
+  },
+];
+
+export const searchCommunes = (query: string): CommuneData[] => {
+  if (!query.trim()) return [];
+  
+  const lowerQuery = query.toLowerCase();
+  return mockCommunes.filter(
+    (commune) =>
+      commune.name.toLowerCase().includes(lowerQuery) ||
+      commune.postalCode.includes(query) ||
+      commune.department.toLowerCase().includes(lowerQuery)
+  );
+};
+
+export const getCommuneById = (id: string): CommuneData | undefined => {
+  return mockCommunes.find((commune) => commune.id === id);
+};
+
+export const getAllCommunes = (): CommuneData[] => {
+  return mockCommunes;
+};
+


### PR DESCRIPTION
## Summary
- implement searchable homepage with commune profile view
- add mock data service and supporting UI components
- define gradient utility styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint setup)
- `npm run build` (fails: Module not found 'lucide-react', 'recharts')

------
https://chatgpt.com/codex/tasks/task_e_68a06445cec08331b3d340c865196f7d