### PR TITLE
fix: resolve missing globe.svg

### DIFF
--- a/src/components/CommuneProfile.tsx
+++ b/src/components/CommuneProfile.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from "recharts";
 import { ArrowLeft, TrendingUp } from "lucide-react";
-import franceMapImage from "/globe.svg";
+const franceMapImage = "/globe.svg";
 
 interface CommuneProfileProps {
   commune: CommuneData;


### PR DESCRIPTION
## Summary
- reference globe.svg from the public directory without module import

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a06b89851c8331af652b37e830627e