### PR TITLE
Refactor home and visualiser pages into modular components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,11 +5,10 @@ import { Header } from "../components/Header";
 import { SearchResults } from "../components/SearchResults";
 import { CommuneProfile } from "../components/CommuneProfile";
 import { CommuneData, searchCommunes, getAllCommunes } from "../services/communeData";
-import { Card } from "../components/ui/card";
-import { Button } from "../components/ui/button";
-import { Input } from "../components/ui/input";
-import { ImageWithFallback } from "../components/figma/ImageWithFallback";
-import { Search, BarChart3, Building2, Plus, CheckCircle } from "lucide-react";
+import { HeroSection } from "../components/home/HeroSection";
+import { CompareSection } from "../components/home/CompareSection";
+import { TrendingSection } from "../components/home/TrendingSection";
+import { TrustSection } from "../components/home/TrustSection";
 
 const franceMapImage = "/globe.svg";
 
@@ -59,61 +58,21 @@ export default function Home() {
     <div className="min-h-screen bg-white">
       <div className="gradient-blue-teal relative overflow-hidden min-h-[70vh]">
         <div className="absolute right-0 top-0 bottom-0 w-1/2 max-w-lg opacity-30">
-          <img src={franceMapImage} alt="Carte de France" className="h-full w-full object-contain object-center-right france-map" />
+          <img
+            src={franceMapImage}
+            alt="Carte de France"
+            className="h-full w-full object-contain object-center-right france-map"
+          />
         </div>
 
         <Header onSearch={handleSearch} searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
 
-        <div className="relative z-10 max-w-7xl mx-auto px-6 pt-8 pb-16">
-          <div className="max-w-2xl">
-            <h1 className="text-7xl font-bold text-white mb-12 leading-tight">
-              Découvrez<br />
-              votre commune
-            </h1>
-
-            <div className="mb-8">
-              <form onSubmit={(e) => { e.preventDefault(); handleSearch(searchQuery); }} className="flex space-x-4">
-                <div className="flex-1 relative">
-                  <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                  <Input
-                    type="text"
-                    placeholder="Rechercher une commune"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="pl-14 h-16 text-lg bg-white border-0 rounded-2xl shadow-xl font-medium text-gray-900 placeholder:text-gray-500"
-                  />
-                </div>
-                <Button
-                  type="submit"
-                  className="h-16 px-10 text-white rounded-2xl shadow-xl font-bold text-lg bg-gradient-to-r from-yellow-400 to-orange-500 hover:from-yellow-500 hover:to-orange-600"
-                >
-                  Explorer
-                </Button>
-              </form>
-            </div>
-
-            <div className="flex space-x-4">
-              <button
-                onClick={() => handleQuickSearch('Nantes')}
-                className="px-5 py-2 bg-white/20 hover:bg-white/30 text-white rounded-full font-medium text-lg"
-              >
-                Nantes
-              </button>
-              <button
-                onClick={() => handleQuickSearch('Lyon')}
-                className="px-5 py-2 bg-white/20 hover:bg-white/30 text-white rounded-full font-medium text-lg"
-              >
-                Lyon
-              </button>
-              <button
-                onClick={() => handleQuickSearch('Bordeaux')}
-                className="px-5 py-2 bg-white/20 hover:bg-white/30 text-white rounded-full font-medium text-lg"
-              >
-                Bordeaux
-              </button>
-            </div>
-          </div>
-        </div>
+        <HeroSection
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          onSearch={handleSearch}
+          onQuickSearch={handleQuickSearch}
+        />
 
         {searchResults.length > 0 && (
           <div className="relative z-10 bg-white/95 backdrop-blur-sm rounded-t-3xl">
@@ -125,140 +84,15 @@ export default function Home() {
       {searchResults.length === 0 && (
         <div className="bg-white">
           <div className="max-w-7xl mx-auto px-6 py-16">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-20">
-              <div>
-                <h2 className="text-3xl font-bold text-gray-900 mb-10">Comparer une commune</h2>
-                <div className="space-y-5">
-                  <Input
-                    placeholder="Commune 1"
-                    value={compareCommune1}
-                    onChange={(e) => setCompareCommune1(e.target.value)}
-                    className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
-                  />
-                  <Input
-                    placeholder="Commune 2"
-                    value={compareCommune2}
-                    onChange={(e) => setCompareCommune2(e.target.value)}
-                    className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
-                  />
-                  <Button className="w-full h-16 bg-teal-600 hover:bg-teal-700 text-white rounded-2xl font-bold text-lg">
-                    Comparer
-                  </Button>
-                </div>
-              </div>
-
-              <div>
-                <div className="flex items-center justify-end mb-8">
-                  <span className="text-sm text-gray-500 font-medium">Annonce</span>
-                </div>
-                <div className="grid grid-cols-3 gap-6">
-                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Châtenay-Malabry')}>
-                    <div className="relative">
-                      <ImageWithFallback
-                        src="https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=300&h=160&fit=crop"
-                        alt="Châtenay-Malabry"
-                        className="w-full h-32 object-cover"
-                      />
-                      <div className="absolute top-3 right-3">
-                        <span className="bg-yellow-400 text-black text-xs px-3 py-1.5 rounded-lg font-bold">
-                          Annoncé
-                        </span>
-                      </div>
-                    </div>
-                    <div className="p-5">
-                      <h3 className="font-bold text-base mb-3 text-gray-900">Chatenay-Malabry</h3>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
-                        <span className="text-base font-semibold text-gray-700">2.8%</span>
-                      </div>
-                    </div>
-                  </Card>
-
-                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Dardilly')}>
-                    <div className="relative">
-                      <ImageWithFallback
-                        src="https://images.unsplash.com/photo-1449824913935-59a10b8d2000?w=300&h=160&fit=crop"
-                        alt="Dardilly"
-                        className="w-full h-32 object-cover"
-                      />
-                    </div>
-                    <div className="p-5">
-                      <h3 className="font-bold text-base mb-3 text-gray-900">Dardilly</h3>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
-                        <span className="text-base font-semibold text-gray-700">13%</span>
-                      </div>
-                    </div>
-                  </Card>
-
-                  <Card className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg" onClick={() => handleQuickSearch('Perpignan')}>
-                    <div className="relative">
-                      <ImageWithFallback
-                        src="https://images.unsplash.com/photo-1467269204594-9661b134dd2b?w=300&h=160&fit=crop"
-                        alt="Perpignan"
-                        className="w-full h-32 object-cover"
-                      />
-                    </div>
-                    <div className="p-5">
-                      <h3 className="font-bold text-base mb-3 text-gray-900">Perpignan</h3>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-3 h-3 bg-teal-500 rounded-full"></div>
-                        <span className="text-base font-semibold text-gray-700">0.47%</span>
-                      </div>
-                    </div>
-                  </Card>
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-24">
-              <div className="flex items-center justify-between mb-12">
-                <h2 className="text-3xl font-bold text-gray-900">Top tendances</h2>
-                <span className="text-sm text-gray-500 font-medium">Annonce</span>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-16">
-                <div className="flex items-center space-x-6">
-                  <div className="w-20 h-20 bg-yellow-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
-                    <BarChart3 className="h-10 w-10 text-white" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-xl text-gray-900">INSEE</h3>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-6">
-                  <div className="w-20 h-20 bg-blue-600 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
-                    <Building2 className="h-10 w-10 text-white" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-xl text-gray-900">Ministère de l'intérieur</h3>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-6">
-                  <div className="w-20 h-20 bg-red-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
-                    <Plus className="h-10 w-10 text-white" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-xl text-gray-900">Santé</h3>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-24">
-              <div className="gradient-yellow-orange rounded-3xl p-12 shadow-xl">
-                <h2 className="text-3xl font-bold text-gray-900 mb-8">Pourquoi nous faire confiance</h2>
-                <div className="space-y-6">
-                  <div className="flex items-center space-x-4">
-                    <CheckCircle className="h-6 w-6 text-gray-900" />
-                    <span className="text-gray-900 font-semibold text-lg">Faits marquant</span>
-                  </div>
-                  <div className="flex items-center space-x-4">
-                    <CheckCircle className="h-6 w-6 text-gray-900" />
-                    <span className="text-gray-900 font-semibold text-lg">Évaluation par Ministre de la Santé</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <CompareSection
+              compareCommune1={compareCommune1}
+              setCompareCommune1={setCompareCommune1}
+              compareCommune2={compareCommune2}
+              setCompareCommune2={setCompareCommune2}
+              onQuickSearch={handleQuickSearch}
+            />
+            <TrendingSection />
+            <TrustSection />
           </div>
         </div>
       )}

--- a/src/components/home/CompareSection.tsx
+++ b/src/components/home/CompareSection.tsx
@@ -1,0 +1,75 @@
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import { FeaturedCommuneCard } from "./FeaturedCommuneCard";
+
+interface CompareSectionProps {
+  compareCommune1: string;
+  setCompareCommune1: (value: string) => void;
+  compareCommune2: string;
+  setCompareCommune2: (value: string) => void;
+  onQuickSearch: (city: string) => void;
+}
+
+export function CompareSection({
+  compareCommune1,
+  setCompareCommune1,
+  compareCommune2,
+  setCompareCommune2,
+  onQuickSearch,
+}: CompareSectionProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-20">
+      <div>
+        <h2 className="text-3xl font-bold text-gray-900 mb-10">Comparer une commune</h2>
+        <div className="space-y-5">
+          <Input
+            placeholder="Commune 1"
+            value={compareCommune1}
+            onChange={(e) => setCompareCommune1(e.target.value)}
+            className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
+          />
+          <Input
+            placeholder="Commune 2"
+            value={compareCommune2}
+            onChange={(e) => setCompareCommune2(e.target.value)}
+            className="h-16 bg-gray-100 border-0 rounded-2xl text-gray-700 font-medium text-lg placeholder:text-gray-500"
+          />
+          <Button className="w-full h-16 bg-teal-600 hover:bg-teal-700 text-white rounded-2xl font-bold text-lg">
+            Comparer
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-end mb-8">
+          <span className="text-sm text-gray-500 font-medium">Annonce</span>
+        </div>
+        <div className="grid grid-cols-3 gap-6">
+          <FeaturedCommuneCard
+            image="https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=300&h=160&fit=crop"
+            alt="Châtenay-Malabry"
+            name="Chatenay-Malabry"
+            percent="2.8%"
+            label="Annoncé"
+            onClick={() => onQuickSearch("Châtenay-Malabry")}
+          />
+          <FeaturedCommuneCard
+            image="https://images.unsplash.com/photo-1449824913935-59a10b8d2000?w=300&h=160&fit=crop"
+            alt="Dardilly"
+            name="Dardilly"
+            percent="13%"
+            onClick={() => onQuickSearch("Dardilly")}
+          />
+          <FeaturedCommuneCard
+            image="https://images.unsplash.com/photo-1467269204594-9661b134dd2b?w=300&h=160&fit=crop"
+            alt="Perpignan"
+            name="Perpignan"
+            percent="0.47%"
+            onClick={() => onQuickSearch("Perpignan")}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/home/FeaturedCommuneCard.tsx
+++ b/src/components/home/FeaturedCommuneCard.tsx
@@ -1,0 +1,37 @@
+import { Card } from "../ui/card";
+import { ImageWithFallback } from "../figma/ImageWithFallback";
+
+interface FeaturedCommuneCardProps {
+  image: string;
+  alt: string;
+  name: string;
+  percent: string;
+  label?: string;
+  onClick: () => void;
+}
+
+export function FeaturedCommuneCard({ image, alt, name, percent, label, onClick }: FeaturedCommuneCardProps) {
+  return (
+    <Card
+      className="overflow-hidden group cursor-pointer hover:shadow-xl transition-all duration-300 rounded-2xl border-0 shadow-lg"
+      onClick={onClick}
+    >
+      <div className="relative">
+        <ImageWithFallback src={image} alt={alt} className="w-full h-32 object-cover" />
+        {label && (
+          <div className="absolute top-3 right-3">
+            <span className="bg-yellow-400 text-black text-xs px-3 py-1.5 rounded-lg font-bold">{label}</span>
+          </div>
+        )}
+      </div>
+      <div className="p-5">
+        <h3 className="font-bold text-base mb-3 text-gray-900">{name}</h3>
+        <div className="flex items-center space-x-2">
+          <div className="w-3 h-3 bg-teal-500 rounded-full" />
+          <span className="text-base font-semibold text-gray-700">{percent}</span>
+        </div>
+      </div>
+    </Card>
+  );
+}
+

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,0 +1,30 @@
+import { SearchForm } from "./SearchForm";
+import { QuickSearch } from "./QuickSearch";
+
+interface HeroSectionProps {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  onSearch: (query: string) => void;
+  onQuickSearch: (city: string) => void;
+}
+
+export function HeroSection({ searchQuery, setSearchQuery, onSearch, onQuickSearch }: HeroSectionProps) {
+  return (
+    <div className="relative z-10 max-w-7xl mx-auto px-6 pt-8 pb-16">
+      <div className="max-w-2xl">
+        <h1 className="text-7xl font-bold text-white mb-12 leading-tight">
+          Découvrez
+          <br />
+          votre commune
+        </h1>
+
+        <div className="mb-8">
+          <SearchForm searchQuery={searchQuery} setSearchQuery={setSearchQuery} onSearch={onSearch} />
+        </div>
+
+        <QuickSearch cities={["Nantes", "Lyon", "Bordeaux"]} onQuickSearch={onQuickSearch} />
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/home/QuickSearch.tsx
+++ b/src/components/home/QuickSearch.tsx
@@ -1,0 +1,21 @@
+interface QuickSearchProps {
+  cities: string[];
+  onQuickSearch: (city: string) => void;
+}
+
+export function QuickSearch({ cities, onQuickSearch }: QuickSearchProps) {
+  return (
+    <div className="flex space-x-4">
+      {cities.map((city) => (
+        <button
+          key={city}
+          onClick={() => onQuickSearch(city)}
+          className="px-5 py-2 bg-white/20 hover:bg-white/30 text-white rounded-full font-medium text-lg"
+        >
+          {city}
+        </button>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/home/SearchForm.tsx
+++ b/src/components/home/SearchForm.tsx
@@ -1,0 +1,39 @@
+import { Search } from "lucide-react";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+
+interface SearchFormProps {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  onSearch: (query: string) => void;
+}
+
+export function SearchForm({ searchQuery, setSearchQuery, onSearch }: SearchFormProps) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSearch(searchQuery);
+      }}
+      className="flex space-x-4"
+    >
+      <div className="flex-1 relative">
+        <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+        <Input
+          type="text"
+          placeholder="Rechercher une commune"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-14 h-16 text-lg bg-white border-0 rounded-2xl shadow-xl font-medium text-gray-900 placeholder:text-gray-500"
+        />
+      </div>
+      <Button
+        type="submit"
+        className="h-16 px-10 text-white rounded-2xl shadow-xl font-bold text-lg bg-gradient-to-r from-yellow-400 to-orange-500 hover:from-yellow-500 hover:to-orange-600"
+      >
+        Explorer
+      </Button>
+    </form>
+  );
+}
+

--- a/src/components/home/TrendingSection.tsx
+++ b/src/components/home/TrendingSection.tsx
@@ -1,0 +1,39 @@
+import { BarChart3, Building2, Plus } from "lucide-react";
+
+export function TrendingSection() {
+  return (
+    <div className="mt-24">
+      <div className="flex items-center justify-between mb-12">
+        <h2 className="text-3xl font-bold text-gray-900">Top tendances</h2>
+        <span className="text-sm text-gray-500 font-medium">Annonce</span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-16">
+        <div className="flex items-center space-x-6">
+          <div className="w-20 h-20 bg-yellow-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+            <BarChart3 className="h-10 w-10 text-white" />
+          </div>
+          <div>
+            <h3 className="font-bold text-xl text-gray-900">INSEE</h3>
+          </div>
+        </div>
+        <div className="flex items-center space-x-6">
+          <div className="w-20 h-20 bg-blue-600 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+            <Building2 className="h-10 w-10 text-white" />
+          </div>
+          <div>
+            <h3 className="font-bold text-xl text-gray-900">Ministère de l'intérieur</h3>
+          </div>
+        </div>
+        <div className="flex items-center space-x-6">
+          <div className="w-20 h-20 bg-red-500 rounded-2xl flex items-center justify-center shrink-0 shadow-lg">
+            <Plus className="h-10 w-10 text-white" />
+          </div>
+          <div>
+            <h3 className="font-bold text-xl text-gray-900">Santé</h3>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/home/TrustSection.tsx
+++ b/src/components/home/TrustSection.tsx
@@ -1,0 +1,22 @@
+import { CheckCircle } from "lucide-react";
+
+export function TrustSection() {
+  return (
+    <div className="mt-24">
+      <div className="gradient-yellow-orange rounded-3xl p-12 shadow-xl">
+        <h2 className="text-3xl font-bold text-gray-900 mb-8">Pourquoi nous faire confiance</h2>
+        <div className="space-y-6">
+          <div className="flex items-center space-x-4">
+            <CheckCircle className="h-6 w-6 text-gray-900" />
+            <span className="text-gray-900 font-semibold text-lg">Faits marquant</span>
+          </div>
+          <div className="flex items-center space-x-4">
+            <CheckCircle className="h-6 w-6 text-gray-900" />
+            <span className="text-gray-900 font-semibold text-lg">Évaluation par Ministre de la Santé</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/visualiser/BirthDeathChart.tsx
+++ b/src/components/visualiser/BirthDeathChart.tsx
@@ -1,0 +1,31 @@
+import { BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface ChartEntry {
+  name: string;
+  value: number;
+  color: string;
+}
+
+export function BirthDeathChart({ data }: { data: ChartEntry[] }) {
+  return (
+    <div className="rounded-xl border p-4 shadow-sm">
+      <h2 className="mb-4 text-lg font-medium">Naissances / Décès 2023</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value">
+              {data.map((entry, index) => (
+                <Cell key={`bd-${index}`} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export default BirthDeathChart;

--- a/src/components/visualiser/ChartsSection.tsx
+++ b/src/components/visualiser/ChartsSection.tsx
@@ -1,0 +1,29 @@
+import GenderChart from './GenderChart';
+import BirthDeathChart from './BirthDeathChart';
+import EmploymentChart from './EmploymentChart';
+
+interface ChartEntry {
+  name: string;
+  value: number;
+  color: string;
+}
+
+export function ChartsSection({
+  genderData,
+  birthDeathData,
+  employmentData,
+}: {
+  genderData: ChartEntry[];
+  birthDeathData: ChartEntry[];
+  employmentData: ChartEntry[];
+}) {
+  return (
+    <section className="grid gap-6 md:grid-cols-2">
+      <GenderChart data={genderData} />
+      <BirthDeathChart data={birthDeathData} />
+      <EmploymentChart data={employmentData} />
+    </section>
+  );
+}
+
+export default ChartsSection;

--- a/src/components/visualiser/EmploymentChart.tsx
+++ b/src/components/visualiser/EmploymentChart.tsx
@@ -1,0 +1,31 @@
+import { BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface ChartEntry {
+  name: string;
+  value: number;
+  color: string;
+}
+
+export function EmploymentChart({ data }: { data: ChartEntry[] }) {
+  return (
+    <div className="rounded-xl border p-4 shadow-sm md:col-span-2">
+      <h2 className="mb-4 text-lg font-medium">Emploi 15–64 ans</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value">
+              {data.map((entry, index) => (
+                <Cell key={`emp-${index}`} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export default EmploymentChart;

--- a/src/components/visualiser/GenderChart.tsx
+++ b/src/components/visualiser/GenderChart.tsx
@@ -1,0 +1,35 @@
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface ChartEntry {
+  name: string;
+  value: number;
+  color: string;
+}
+
+export function GenderChart({ data }: { data: ChartEntry[] }) {
+  return (
+    <div className="rounded-xl border p-4 shadow-sm">
+      <h2 className="mb-4 text-lg font-medium">Répartition H/F</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={40}
+              outerRadius={80}
+            >
+              {data.map((entry, index) => (
+                <Cell key={`g-${index}`} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export default GenderChart;

--- a/src/components/visualiser/StatCard.tsx
+++ b/src/components/visualiser/StatCard.tsx
@@ -1,0 +1,17 @@
+interface StatCardProps {
+  title: string;
+  value: string;
+  sub?: string;
+}
+
+export function StatCard({ title, value, sub }: StatCardProps) {
+  return (
+    <div className="rounded-xl border p-4 shadow-sm">
+      <h2 className="mb-2 text-sm font-medium text-gray-500">{title}</h2>
+      <p className="text-2xl font-bold">{value}</p>
+      {sub && <p className="mt-1 text-sm text-gray-600">{sub}</p>}
+    </div>
+  );
+}
+
+export default StatCard;

--- a/src/components/visualiser/StatsSection.tsx
+++ b/src/components/visualiser/StatsSection.tsx
@@ -1,0 +1,27 @@
+import StatCard from './StatCard';
+import { CommuneData } from './types';
+
+export function StatsSection({ row }: { row: CommuneData }) {
+  return (
+    <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard title="Population" value={`${fmtInt(row.P22_POP)} hab.`} />
+      <StatCard title="Superficie" value={`${fmtNumber(row.SUPERF)} km²`} />
+      <StatCard
+        title="Logements"
+        value={fmtInt(row.P22_LOG)}
+        sub={`${fmtInt(row.P22_LOGVAC)} vacants`}
+      />
+      <StatCard title="Médecins" value={fmtInt(row.MED21)} />
+    </section>
+  );
+}
+
+function fmtInt(n?: number) {
+  return Number.isFinite(n) ? Math.round(n!).toLocaleString('fr-FR') : '—';
+}
+
+function fmtNumber(n?: number) {
+  return Number.isFinite(n) ? Number(n!).toLocaleString('fr-FR') : '—';
+}
+
+export default StatsSection;

--- a/src/components/visualiser/VisualiserHeader.tsx
+++ b/src/components/visualiser/VisualiserHeader.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export function VisualiserHeader({ code }: { code: string }) {
+  return (
+    <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <h1 className="text-3xl font-semibold">
+        Commune <span className="text-gray-500">({code})</span>
+      </h1>
+      <Link
+        href="/"
+        className="self-start rounded-md bg-blue-600 px-4 py-2 text-sm text-white"
+      >
+        Comparer cette commune
+      </Link>
+    </header>
+  );
+}
+
+export default VisualiserHeader;

--- a/src/components/visualiser/types.ts
+++ b/src/components/visualiser/types.ts
@@ -1,0 +1,14 @@
+export interface CommuneData {
+  CODGEO: string;
+  P22_POP: number;
+  SUPERF: number;
+  NAIS23: number;
+  DECES23: number;
+  P22_LOG: number;
+  P22_LOGVAC: number;
+  MED21: number;
+  P22_CHOM1564: number;
+  P22_ACT1564: number;
+  P22_POPH: number;
+  P22_POPF: number;
+}


### PR DESCRIPTION
## Summary
- Extract hero, comparison, trending, and trust sections into dedicated components for the home page
- Modularize visualiser page with header, stats, and chart components for easier maintenance

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)
- `npm run build` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0d8dc4a4c8331be7628f3cadb1227